### PR TITLE
Don't decref Py_None in case

### DIFF
--- a/bindings/python/rrdtoolmodule.c
+++ b/bindings/python/rrdtoolmodule.c
@@ -1064,7 +1064,9 @@ _rrdtool_lastupdate(PyObject *Py_UNUSED(self), PyObject *args)
             }
 
             PyDict_SetItemString(ds_dict, ds_names[i], val);
-            Py_DECREF(val);
+            
+            if (val != Py_None)
+                Py_DECREF(val);
 
             free(last_ds[i]);
             free(ds_names[i]);


### PR DESCRIPTION
Fix for user-reported issue with the lastupdate wrapper function. Don't decrease reference on Py_None here, otherwise fatal Python errors may occur.